### PR TITLE
integrate lsscsi workaround for disk discovery from bpo for testing on olders distros

### DIFF
--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -40,9 +40,6 @@ __scan_scsi_devices(void)
     /* remove old devices from global device table */
     moreinfo_del_with_prefix("DEV:SCSI");
 
-    if (!g_file_test("/proc/scsi/scsi", G_FILE_TEST_EXISTS))
-	return;
-
     scsi_storage_list = g_strdup(_("\n[SCSI Disks]\n"));
 
     int otype = 0;

--- a/modules/devices/storage.c
+++ b/modules/devices/storage.c
@@ -45,7 +45,14 @@ __scan_scsi_devices(void)
 
     scsi_storage_list = g_strdup(_("\n[SCSI Disks]\n"));
 
-    if ((proc_scsi = fopen("/proc/scsi/scsi", "r"))) {
+    int otype = 0;
+    if (proc_scsi = fopen("/proc/scsi/scsi", "r")) {
+        otype = 1;
+    } else if (proc_scsi = popen("lsscsi -c", "r")) {
+        otype = 2;
+    }
+
+    if (otype) {
         while (fgets(buffer, 256, proc_scsi)) {
             buf = g_strstrip(buffer);
             if (!strncmp(buf, "Host: scsi", 10)) {
@@ -145,7 +152,10 @@ __scan_scsi_devices(void)
                 scsi_controller = scsi_channel = scsi_id = scsi_lun = 0;
             }
         }
-        fclose(proc_scsi);
+        if (otype == 1)
+            fclose(proc_scsi);
+        else if (otype == 2)
+            pclose(proc_scsi);
     }
 
     if (n) {


### PR DESCRIPTION
integrate lsscsi workaround for disk discovery from bpo for testing on olders distros