### PR TITLE
vendor.c: try and reduce the likelihood of false matches #242

### DIFF
--- a/hardinfo/vendor.c
+++ b/hardinfo/vendor.c
@@ -26,98 +26,108 @@
 #include "config.h"
 #include "hardinfo.h"
 
-static const Vendor vendors[] = {
-    {"ATI", "ATI Technologies", "www.ati.com"},
-    {"nVidia", "nVidia", "www.nvidia.com"},
-    {"NVidia", "nVidia", "www.nvidia.com"},
-    {"3Com", "3Com", "www.3com.com"},
-    {"Intel", "Intel", "www.intel.com"},
-    {"Cirrus Logic", "Cirrus Logic", "www.cirrus.com"},
-    {"VIA Technologies", "VIA Technologies", "www.via.com.tw"},
-    {"VIA", "VIA Technologies", "www.via.com.tw"},
-    {"hp", "Hewlett-Packard", "www.hp.com"},
-    {"NEC Corporation", "NEC Coporation", "www.nec.com"},
-    {"MAXTOR", "MAXTOR", "www.maxtor.com"},
-    {"SAMSUNG", "SAMSUNG", "www.samsung.com"},
-    {"PIONEER", "PIONEER", "www.pioneer-eur.com"},
-    {"PLEXTOR", "PLEXTOR", "www.plextor.be"},
-    {"Realtek Semiconductor", "Realtek", "www.realtek.com.tw"},
-    {"TOSHIBA", "TOSHIBA", "www.toshiba.com"},
-    {"LITE-ON", "LITE-ON", "www.liteonit.com"},
-    {"WDC", "Western Digital", "www.wdc.com"},
-    {"HL-DT-ST", "LG Electronics", "www.lge.com"},
-    {"ST", "SEAGATE", "www.seagate.com"},
-    {"Lexmark", "Lexmark", "www.lexmark.com"},
-    {"_NEC", "NEC Corporation", "www.nec.com"},
-    {"Creative Labs", "Creative Labs", "www.creative.com"},
-    {"Brooktree", "Conexant", "www.brooktree.com"},
-    {"Atheros", "Atheros Communications", "www.atheros.com"},
-    {"MATSHITA", "Panasonic", "www.panasonic.com"},
-    {"Silicon Image", "Silicon Image", "www.siliconimage.com"},
-    {"Silicon Integrated Image", "Silicon Image", "www.siliconimage.com"},
-    {"KYE", "KYE Systems", "www.genius-kye.com"},
-    {"Broadcom", "Broadcom", "www.broadcom.com"},
-    {"Apple", "Apple", "www.apple.com"},
-    {"IBM", "IBM", "www.ibm.com"},
-    {"Dell", "Dell Computer", "www.dell.com"},
-    {"Logitech", "Logitech International", "www.logitech.com"},
-    {"FUJITSU", "Fujitsu", "www.fujitsu.com"},
-    {"CDU", "Sony", "www.sony.com"},
-    {"SanDisk", "SanDisk", "www.sandisk.com"},
-    {"ExcelStor", "ExcelStor Technology", "www.excelstor.com"},
-    {"D-Link", "D-Link", "www.dlink.com.tw"},
-    {"Giga-byte", "Gigabyte Technology", "www.gigabyte.com.tw"},
-    {"Gigabyte", "Gigabyte Technology", "www.gigabyte.com.tw"},
-    {"C-Media", "C-Media Electronics", "www.cmedia.com.tw"},
-    {"Avermedia", "AVerMedia Technologies", "www.aver.com"},
-    {"Philips", "Philips", "www.philips.com"},
-    {"RaLink", "Ralink Technology", "www.ralinktech.com"},
-    {"Siemens", "Siemens AG", "www.siemens.com"},
-    {"HP", "Hewlett-Packard", "www.hp.com"},
-    {"Hewlett-Packard", "Hewlett-Packard", "www.hp.com"},
-    {"TEAC", "TEAC America", "www.teac.com"},
-    {"Microsoft", "Microsoft", "www.microsoft.com"},
-    {"Memorex", "Memorex Products", "www.memorex.com"},
-    {"eMPIA", "eMPIA Technology", "www.empiatech.com.tw"},
-    {"Canon", "Canon", "www.canon.com"},
-    {"A4Tech", "A4tech", "www.a4tech.com"},
-    {"ALCOR", "Alcor", "www.alcor.org"},
-    {"Vimicro", "Vimicro", "www.vimicro.com"},
-    {"OTi", "Ours Technology", "www.oti.com.tw"},
-    {"BENQ", "BenQ", "www.benq.com"},
-    {"Acer", "Acer", "www.acer.com"},
-    {"QUANTUM", "Quantum", "www.quantum.com"},
-    {"Kingston", "Kingston", "www.kingston.com"},
-    {"Chicony", "Chicony", "www.chicony.com.tw"},
-    {"Genius", "Genius", "www.genius.ru"},
+/* { match_string, name, url } */
+static Vendor vendors[] = {
+    { "ASUS", 0, "ASUS", "www.asus.com" }, /* "ASUSTek" is common */
+    { "ATI", 1, "ATI Technologies", "www.ati.com" },
+    { "nVidia", 0, "nVidia", "www.nvidia.com" },
+    { "3Com", 0, "3Com", "www.3com.com" },
+    { "Intel", 0, "Intel", "www.intel.com" },
+    { "Cirrus Logic", 0, "Cirrus Logic", "www.cirrus.com" },
+    { "VIA", 1, "VIA Technologies", "www.via.com.tw" },
+    { "NEC", 1, "NEC Corporation", "www.nec.com"},
+    { "Realtek", 0, "Realtek", "www.realtek.com.tw"},
+    { "Toshiba", 0, "Toshiba", "www.toshiba.com"},
+    { "LITE-ON", 1, "LITE-ON", "www.liteonit.com"},
+    { "Maxtor", 0, "Maxtor", "www.maxtor.com"},
+    { "Samsung", 0, "Samsung", "www.samsung.com"},
+    { "Pioneer", 0, "Pioneer", "www.pioneer-eur.com"},
+    { "Plextor", 0, "Plextor", "www.plextor.be"},
+    { "WDC", 1, "Western Digital", "www.wdc.com"},
+    { "HL-DT-ST", 1, "LG Electronics", "www.lge.com"},
+    { "Lexmark", 0, "Lexmark", "www.lexmark.com"},
+    { "Creative Labs", 0, "Creative Labs", "www.creative.com"},
+    { "Brooktree", 0, "Conexant", "www.brooktree.com"},
+    { "Atheros", 0, "Atheros Communications", "www.atheros.com"},
+    { "MATSHITA", 0, "Panasonic", "www.panasonic.com"},
+    { "Silicon Image", 0, "Silicon Image", "www.siliconimage.com"},
+    { "Silicon Integrated Image", 0, "Silicon Image", "www.siliconimage.com"},
+    { "Broadcom", 0, "Broadcom", "www.broadcom.com"},
+    { "Apple", 0, "Apple", "www.apple.com"},
+    { "IBM", 1, "IBM", "www.ibm.com"},
+    { "Dell", 0, "Dell Computer", "www.dell.com"},
+    { "Logitech", 0, "Logitech International", "www.logitech.com"},
+    { "FUJITSU", 0, "Fujitsu", "www.fujitsu.com"},
+    { "CDU", 1, "Sony", "www.sony.com"},
+    { "SanDisk", 0, "SanDisk", "www.sandisk.com"},
+    { "ExcelStor", 0, "ExcelStor Technology", "www.excelstor.com"},
+    { "D-Link", 0, "D-Link", "www.dlink.com.tw"},
+    { "Giga-byte", 0, "Gigabyte Technology", "www.gigabyte.com.tw"},
+    { "Gigabyte", 0, "Gigabyte Technology", "www.gigabyte.com.tw"},
+    { "C-Media", 0, "C-Media Electronics", "www.cmedia.com.tw"},
+    { "Avermedia", 0, "AVerMedia Technologies", "www.aver.com"},
+    { "Philips", 0, "Philips", "www.philips.com"},
+    { "RaLink", 0, "Ralink Technology", "www.ralinktech.com"},
+    { "Siemens", 0, "Siemens AG", "www.siemens.com"},
+    { "Hewlett-Packard", 0, "Hewlett-Packard", "www.hp.com"},
+    { "HP", 1, "Hewlett-Packard", "www.hp.com"},
+    { "TEAC", 1, "TEAC America", "www.teac.com"},
+    { "Microsoft", 0, "Microsoft", "www.microsoft.com"},
+    {" Memorex", 0, "Memorex Products", "www.memorex.com"},
+    { "eMPIA", 1, "eMPIA Technology", "www.empiatech.com.tw"},
+    { "Canon", 0, "Canon", "www.canon.com"},
+    { "A4Tech", 0, "A4tech", "www.a4tech.com"},
+    { "ALCOR", 0, "Alcor", "www.alcor.org"},
+    { "Vimicro", 0, "Vimicro", "www.vimicro.com"},
+    { "OTi", 1, "Ours Technology", "www.oti.com.tw"},
+    { "BENQ", 0, "BenQ", "www.benq.com"},
+    { "Acer", 0, "Acer", "www.acer.com"},
+    { "QUANTUM", 0, "Quantum", "www.quantum.com"},
+    { "Kingston", 0, "Kingston", "www.kingston.com"},
+    { "Chicony", 0, "Chicony", "www.chicony.com.tw"},
+    { "Genius", 0, "Genius", "www.genius.ru"},
+    { "KYE", 1, "KYE Systems", "www.genius-kye.com"},
+    { "ST", 1, "SEAGATE", "www.seagate.com"},
+
     /* BIOS manufacturers */
-    {"American Megatrends", "American Megatrends", "www.ami.com"},
-    {"Award", "Award Software International", "www.award-bios.com"},
-    {"Phoenix", "Phoenix Technologies", "www.phoenix.com"},
+    { "American Megatrends", 0, "American Megatrends", "www.ami.com"},
+    { "Award", 0, "Award Software International", "www.award-bios.com"},
+    { "Phoenix", 0, "Phoenix Technologies", "www.phoenix.com"},
     /* x86 vendor strings */
-    { "AMDisbetter!", "Advanced Micro Devices", "www.amd.com" },
-    { "AuthenticAMD", "Advanced Micro Devices", "www.amd.com" },
-    { "CentaurHauls", "VIA (formerly Centaur Technology)", "www.via.tw" },
-    { "CyrixInstead", "Cyrix", "" },
-    { "GenuineIntel", "Intel", "www.intel.com" },
-    { "TransmetaCPU", "Transmeta", "" },
-    { "GenuineTMx86", "Transmeta", "" },
-    { "Geode by NSC", "National Semiconductor", "" },
-    { "NexGenDriven", "NexGen", "" },
-    { "RiseRiseRise", "Rise Technology", "" },
-    { "SiS SiS SiS", "Silicon Integrated Systems", "" },
-    { "UMC UMC UMC", "United Microelectronics Corporation", "" },
-    { "VIA VIA VIA", "VIA", "www.via.tw" },
-    { "Vortex86 SoC", "DMP Electronics", "" },
+    { "AMDisbetter!", 0, "Advanced Micro Devices", "www.amd.com" },
+    { "AuthenticAMD", 0, "Advanced Micro Devices", "www.amd.com" },
+    { "CentaurHauls", 0, "VIA (formerly Centaur Technology)", "www.via.tw" },
+    { "CyrixInstead", 0, "Cyrix", "" },
+    { "GenuineIntel", 0, "Intel", "www.intel.com" },
+    { "TransmetaCPU", 0, "Transmeta", "" },
+    { "GenuineTMx86", 0, "Transmeta", "" },
+    { "Geode by NSC", 0, "National Semiconductor", "" },
+    { "NexGenDriven", 0, "NexGen", "" },
+    { "RiseRiseRise", 0, "Rise Technology", "" },
+    { "SiS SiS SiS", 0, "Silicon Integrated Systems", "" },
+    { "UMC UMC UMC", 0, "United Microelectronics Corporation", "" },
+    { "VIA VIA VIA", 0, "VIA", "www.via.tw" },
+    { "Vortex86 SoC", 0, "DMP Electronics", "" },
     /* x86 VM vendor strings */
-    { "KVMKVMKVM", "KVM", "" },
-    { "Microsoft Hv", "Microsoft Hyper-V", "www.microsoft.com" },
-    { "lrpepyh vr", "Parallels", "" },
-    { "VMwareVMware", "VMware", "" },
-    { "XenVMMXenVMM", "Xen HVM", "" },
+    { "KVMKVMKVM", 0, "KVM", "" },
+    { "Microsoft Hv", 0, "Microsoft Hyper-V", "www.microsoft.com" },
+    { "lrpepyh vr", 0, "Parallels", "" },
+    { "VMwareVMware", 0, "VMware", "" },
+    { "XenVMMXenVMM", 0, "Xen HVM", "" },
 };
 
 static GSList *vendor_list = NULL;
+
+/* sort the vendor list by length of match_string,
+ * LONGEST first */
+gint vendor_sort (gconstpointer a, gconstpointer b) {
+    int la = 0, lb = 0;
+    if (a) la = strlen(a);
+    if (b) lb = strlen(b);
+    if (a == b) return 0;
+    if (a > b) return -1;
+    return 1;
+}
 
 void vendor_init(void)
 {
@@ -156,7 +166,12 @@ void vendor_init(void)
 
           tmp = g_strdup_printf("vendor%d", i);
 
-          v->id   = g_key_file_get_string(vendors, tmp, "id", NULL);
+          v->match_string = g_key_file_get_string(vendors, tmp, "match_string", NULL);
+          if (v->match_string == NULL) {
+              /* try old name */
+              v->match_string = g_key_file_get_string(vendors, tmp, "id", NULL);
+          }
+          v->match_case = g_key_file_get_integer(vendors, tmp, "match_case", NULL);
           v->name = g_key_file_get_string(vendors, tmp, "name", NULL);
           v->url  = g_key_file_get_string(vendors, tmp, "url", NULL);
 
@@ -175,42 +190,58 @@ void vendor_init(void)
       }
     }
 
+    /* sort the vendor list by length of match string so that short strings are
+     * less likely to incorrectly match.
+     * example: ST matches ASUSTeK but SEAGATE is not ASUS */
+    vendor_list = g_slist_sort(vendor_list, &vendor_sort);
+
     g_free(path);
 }
 
-const gchar *vendor_get_name(const gchar * id)
+const gchar *vendor_get_name(const gchar * id_str)
 {
     GSList *vendor;
 
-    if (!id) {
-      return NULL;
-    }
+    if (!id_str)
+        return NULL;
 
     for (vendor = vendor_list; vendor; vendor = vendor->next) {
-      Vendor *v = (Vendor *)vendor->data;
+        Vendor *v = (Vendor *)vendor->data;
 
-      if (v && v->id && strstr(id, v->id)) {
-        return v->name;
-      }
+        if (v)
+            if (v->match_case) {
+                if (v->match_string && strstr(id_str, v->match_string))
+                    return v->name;
+            } else {
+                if (v->match_string && strcasestr(id_str, v->match_string))
+                    return v->name;
+            }
+
     }
 
-    return id; /* What about const? */
+    return id_str; /* What about const? */
 }
 
-const gchar *vendor_get_url(const gchar * id)
+const gchar *vendor_get_url(const gchar * id_str)
 {
     GSList *vendor;
 
-    if (!id) {
+    if (!id_str) {
       return NULL;
     }
 
     for (vendor = vendor_list; vendor; vendor = vendor->next) {
-      Vendor *v = (Vendor *)vendor->data;
+        Vendor *v = (Vendor *)vendor->data;
 
-      if (v && v->id && strstr(id, v->id)) {
-        return v->url;
-      }
+        if (v)
+            if (v->match_case) {
+                if (v->match_string && strstr(id_str, v->match_string))
+                    return v->url;
+            } else {
+                if (v->match_string && strcasestr(id_str, v->match_string))
+                    return v->url;
+            }
+
     }
 
     return NULL;

--- a/includes/vendor.h
+++ b/includes/vendor.h
@@ -21,13 +21,14 @@
 
 typedef struct _Vendor	Vendor;
 struct _Vendor {
-  char *id;
+  char *match_string;
+  int match_case; /* 0 = ignore case, 1 = match case*/
   char *name;
   char *url;
 };
 
 void  vendor_init(void);
-const gchar *vendor_get_name(const gchar *id);
-const gchar *vendor_get_url(const gchar *id);
+const gchar *vendor_get_name(const gchar *id_str);
+const gchar *vendor_get_url(const gchar *id_str);
 
 #endif	/* __VENDOR_H__ */


### PR DESCRIPTION
* Rename struct members to be less ambiguous
* Sort the list by length of match_string, longest first,
  so better matches match first
* Add flag to force case-sensitive matching so that two or
  three-letter names don't match names that happen to have
  those letters in them

Also, added ASUS and fixes #241.
(https://github.com/lpereira/hardinfo/issues/241)

Signed-off-by: Burt P <pburt0@gmail.com>